### PR TITLE
feat: Add CLAUDE.md and update README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,25 +5,36 @@
     "url": "https://github.com/duyet"
   },
   "metadata": {
-    "description": "A collection of plugins for Claude Code to enhance productivity and workflow automation",
+    "description": "A curated collection of plugins for Claude Code to enhance productivity and workflow automation",
     "version": "1.0.0",
     "homepage": "https://github.com/duyet/claude-plugins",
-    "pluginRoot": "./plugins"
+    "pluginRoot": "./plugins",
+    "totalPlugins": 1,
+    "lastUpdated": "2025-11-17"
   },
   "plugins": [
     {
       "name": "commit-commands",
       "source": "./plugins/commit-commands.md",
-      "description": "Create a git commit with semantic commit message format. Automatically analyzes staged and unstaged changes, reviews recent commits, and follows semantic commit conventions.",
+      "description": "Automatically creates semantic git commits by analyzing staged and unstaged changes, reviewing recent commit history, and following conventional commit message format (feat, fix, docs, refactor, etc.)",
       "version": "1.0.0",
+      "category": "git",
+      "keywords": [
+        "git",
+        "commit",
+        "semantic-commit",
+        "conventional-commits",
+        "workflow",
+        "automation",
+        "version-control"
+      ],
       "author": {
         "name": "Duyet",
         "url": "https://github.com/duyet"
       },
       "repository": "https://github.com/duyet/claude-plugins",
+      "homepage": "https://github.com/duyet/claude-plugins#-commit-commands",
       "license": "MIT",
-      "keywords": ["git", "commit", "semantic-commit", "workflow", "automation"],
-      "category": "git",
       "strict": false
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,47 +1,243 @@
-# Claude Plugins Marketplace
+# Duyet's Claude Plugins Marketplace
 
-This repository contains a collection of plugins designed for Claude Code to enhance productivity and workflow automation.
+This repository is a Claude Code plugin marketplace, providing a collection of plugins to enhance productivity and workflow automation.
 
 ## Repository Structure
 
 ```
 claude-plugins/
-├── plugins/          # Plugin files
-│   └── *.md         # Individual plugin definitions
-├── README.md        # User-facing documentation
-└── CLAUDE.md        # This file - Claude-specific information
+├── .claude-plugin/
+│   └── marketplace.json    # Marketplace configuration (required)
+├── plugins/                # Plugin files
+│   └── commit-commands.md  # Individual plugin definitions
+├── CLAUDE.md              # This file - Claude-specific information
+└── README.md              # User-facing documentation
+```
+
+## Marketplace Configuration
+
+### marketplace.json Schema
+
+The `.claude-plugin/marketplace.json` file follows the official Claude Code marketplace schema:
+
+```json
+{
+  "name": "string (kebab-case, required)",
+  "owner": {
+    "name": "string (required)",
+    "email": "string (optional)",
+    "url": "string (optional)"
+  },
+  "metadata": {
+    "description": "string",
+    "version": "string",
+    "homepage": "string",
+    "pluginRoot": "string (base path for relative sources)"
+  },
+  "plugins": [
+    {
+      "name": "string (required, kebab-case)",
+      "source": "string|object (required)",
+      "description": "string",
+      "version": "string",
+      "author": { "name": "string", "url": "string" },
+      "repository": "string",
+      "license": "string (SPDX identifier)",
+      "keywords": ["array of strings"],
+      "category": "string",
+      "strict": boolean
+    }
+  ]
+}
+```
+
+**Key Points:**
+- `name`: Marketplace identifier in kebab-case
+- `owner`: Maintainer information (replaces old `author` field)
+- `metadata`: Contains description, version, homepage, and pluginRoot
+- `plugins[]`: Array of plugin entries
+- `source`: Can be relative path, GitHub repo, or git URL
+- `strict`: When `false`, plugin.json is optional (marketplace entry is the manifest)
+
+### Plugin Source Types
+
+**Relative paths** (plugins in same repository):
+```json
+{ "source": "./plugins/my-plugin" }
+```
+
+**GitHub repositories:**
+```json
+{
+  "source": {
+    "source": "github",
+    "repo": "owner/plugin-repo"
+  }
+}
+```
+
+**Git repositories:**
+```json
+{
+  "source": {
+    "source": "git",
+    "url": "https://gitlab.com/team/plugin.git"
+  }
+}
 ```
 
 ## Plugin Format
 
-Each plugin is a markdown file with:
+### Single-File Plugins (used in this marketplace)
 
-1. **YAML Frontmatter**: Configuration metadata
-   - `allowedTools`: Array of tools Claude can use with this plugin
-   - `description`: Brief description of the plugin's purpose
+For simple plugins, use a single markdown file with YAML frontmatter:
 
-2. **Content**: Instructions and context for Claude to follow
+```markdown
+---
+allowed-tools: Bash(command:*), Read, Write
+description: Plugin description
+---
+
+## Context
+
+Instructions and context for Claude...
+
+## Your task
+
+Clear task description...
+```
+
+**When using single-file format:**
+- Set `"strict": false` in marketplace.json
+- The marketplace entry serves as the complete manifest
+- No separate `plugin.json` file needed
+
+### Multi-File Plugins
+
+For complex plugins with multiple components:
+- Create a plugin directory
+- Include `plugin.json` manifest file
+- Set `"strict": true` (or omit, as it's default)
+- Can include: commands/, agents/, hooks/, mcpServers/
 
 ## Available Plugins
 
-### Commit Commands Plugin
-- **Location**: `plugins/commit-commands.md`
-- **Purpose**: Creates semantic git commits by analyzing changes and following conventional commit format
-- **Allowed Tools**: Bash (for git operations)
+### commit-commands
 
-## Usage Context
+**Location:** `plugins/commit-commands.md`
+**Type:** Single-file command plugin
+**Format:** Markdown with YAML frontmatter
 
-When users reference plugins from this marketplace, they expect:
-- Consistent behavior following the plugin's instructions
-- Use of semantic commit conventions where applicable
-- Following best practices for the specific domain (git, code analysis, etc.)
+**Purpose:** Creates semantic git commits by analyzing staged/unstaged changes and following conventional commit format.
+
+**Allowed Tools:** Bash (for git operations)
+
+**Usage:** Install via marketplace or directly invoke after marketplace is added.
+
+## How Users Access This Marketplace
+
+### Add the Marketplace
+
+```bash
+/plugin marketplace add duyet/claude-plugins
+```
+
+### Install Plugins
+
+```bash
+# Install specific plugin
+/plugin install commit-commands@duyets-claude-plugins
+
+# Browse all plugins interactively
+/plugin
+```
+
+### Team Configuration
+
+Teams can auto-install this marketplace via `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "duyets-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "duyet/claude-plugins"
+      }
+    }
+  }
+}
+```
 
 ## Contributing New Plugins
 
-When creating new plugins:
-1. Place them in the `plugins/` directory
-2. Use descriptive filenames (kebab-case)
-3. Include proper YAML frontmatter
-4. Provide clear, actionable instructions
-5. Specify required tools in `allowedTools`
-6. Test the plugin before committing
+### For Single-File Plugins
+
+1. Create a markdown file in `plugins/` directory
+2. Add YAML frontmatter with `allowed-tools` and `description`
+3. Write clear instructions in the content
+4. Update `.claude-plugin/marketplace.json`:
+   ```json
+   {
+     "name": "plugin-name",
+     "source": "./plugins/plugin-name.md",
+     "description": "Clear description",
+     "version": "1.0.0",
+     "author": { "name": "Your Name" },
+     "keywords": ["relevant", "tags"],
+     "strict": false
+   }
+   ```
+5. Test the plugin locally
+6. Submit a pull request
+
+### For Multi-File Plugins
+
+1. Create a directory in `plugins/`
+2. Add `plugin.json` manifest
+3. Organize commands, agents, hooks as needed
+4. Update marketplace.json with `"strict": true` (or omit)
+5. Test and submit PR
+
+### Best Practices
+
+- Use kebab-case for plugin names
+- Provide clear, concise descriptions
+- Add relevant keywords for discoverability
+- Specify accurate version numbers
+- Test plugins before submitting
+- Follow semantic versioning
+- Document plugin usage in README.md
+
+## Marketplace Management
+
+### Validation
+
+Test your marketplace locally:
+
+```bash
+# Validate marketplace JSON
+claude plugin validate .
+
+# Add local marketplace
+/plugin marketplace add ./path/to/claude-plugins
+
+# Test plugin installation
+/plugin install commit-commands@duyets-claude-plugins
+```
+
+### Versioning
+
+- Marketplace version in `metadata.version`
+- Individual plugin versions in each plugin entry
+- Follow semantic versioning (MAJOR.MINOR.PATCH)
+
+## References
+
+- [Official Plugin Marketplaces Documentation](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)
+- [Plugin Development Guide](https://docs.claude.com/en/docs/claude-code/plugins)
+- [Plugin Reference](https://docs.claude.com/en/docs/claude-code/plugins-reference)
+
+## License
+
+MIT - See individual plugin entries for specific licensing information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Duyet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
 # Duyet's Claude Plugins Marketplace
 
-A collection of plugins for Claude Code to enhance productivity and workflow automation.
+A curated collection of plugins for Claude Code to enhance productivity and workflow automation.
 
-## Installation
+## Quick Start
 
-### Add This Marketplace
+### 1. Add This Marketplace
 
-Add this marketplace to your Claude Code to access all available plugins:
+Add this marketplace to your Claude Code:
 
 ```bash
 /plugin marketplace add duyet/claude-plugins
 ```
 
-### Install Plugins
+### 2. Install Plugins
 
-Once the marketplace is added, install plugins using:
+Once the marketplace is added, install plugins:
 
 ```bash
-# Install from this marketplace
+# Install specific plugin from this marketplace
 /plugin install commit-commands@duyets-claude-plugins
 
 # Or browse all available plugins interactively
 /plugin
 ```
 
-### Alternative: Direct Plugin Installation
+### Alternative: Direct Installation
 
-You can also install individual plugins directly without adding the marketplace:
+Install individual plugins directly without adding the marketplace:
 
 ```bash
 /plugin install https://github.com/duyet/claude-plugins/raw/main/plugins/commit-commands.md
@@ -36,29 +36,33 @@ You can also install individual plugins directly without adding the marketplace:
 
 ### 🚀 Commit Commands
 
-**Name:** `commit-commands`
-**File:** [`plugins/commit-commands.md`](plugins/commit-commands.md)
+**Plugin Name:** `commit-commands`
+**Source:** [`plugins/commit-commands.md`](plugins/commit-commands.md)
+**Category:** Git & Version Control
 
-Automatically creates semantic git commits by analyzing your staged changes.
+Automatically creates semantic git commits by analyzing your staged changes and commit history.
 
-**Usage:**
+**How to use:**
 ```bash
 # Stage your changes
 git add .
 
-# Invoke the commit-commands plugin in Claude Code
-# The plugin will analyze changes and create a semantic commit message
+# Invoke the plugin (after installation)
+# The plugin analyzes changes and creates a semantic commit
 ```
 
 **Features:**
-- Analyzes staged and unstaged changes
-- Reviews recent commit history for consistency
-- Follows semantic commit conventions (feat, fix, docs, etc.)
-- Generates concise, meaningful commit messages
+- ✓ Analyzes staged and unstaged changes
+- ✓ Reviews recent commit history for consistency
+- ✓ Follows semantic commit conventions (feat, fix, docs, refactor, etc.)
+- ✓ Generates concise, meaningful commit messages
+- ✓ Works with git hooks and pre-commit validation
 
 ## For Teams
 
-Set up automatic marketplace installation for team projects by adding to `.claude/settings.json`:
+### Auto-Install Marketplace for Team Projects
+
+Configure automatic marketplace installation by adding to your project's `.claude/settings.json`:
 
 ```json
 {
@@ -73,13 +77,59 @@ Set up automatic marketplace installation for team projects by adding to `.claud
 }
 ```
 
-When team members trust the repository folder, Claude Code automatically installs this marketplace.
+When team members trust the repository, Claude Code automatically installs this marketplace.
+
+### Enable Specific Plugins
+
+You can also pre-install specific plugins for your team:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "duyets-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "duyet/claude-plugins"
+      }
+    }
+  },
+  "enabledPlugins": [
+    "commit-commands@duyets-claude-plugins"
+  ]
+}
+```
+
+## Contributing
+
+We welcome contributions! To add a new plugin:
+
+1. Fork this repository
+2. Create a new plugin file in `plugins/` directory
+3. Update `.claude-plugin/marketplace.json` with your plugin entry
+4. Test your plugin locally
+5. Submit a pull request
+
+See [CLAUDE.md](CLAUDE.md) for detailed contribution guidelines and plugin format specifications.
 
 ## Documentation
 
-- **CLAUDE.md**: Repository structure and plugin format documentation
-- **Marketplace Config**: `.claude-plugin/marketplace.json` contains all marketplace metadata
+- **[CLAUDE.md](CLAUDE.md)** - Complete marketplace documentation, schema reference, and contribution guide
+- **[.claude-plugin/marketplace.json](.claude-plugin/marketplace.json)** - Marketplace configuration and plugin registry
+- **[Official Docs](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)** - Claude Code plugin marketplaces documentation
 
-## License
+## Marketplace Information
 
-MIT
+**Marketplace ID:** `duyets-claude-plugins`
+**Owner:** [Duyet](https://github.com/duyet)
+**Version:** 1.0.0
+**License:** MIT
+
+## Support
+
+- **Issues:** [GitHub Issues](https://github.com/duyet/claude-plugins/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/duyet/claude-plugins/discussions)
+- **Official Docs:** [Claude Code Documentation](https://docs.claude.com/en/docs/claude-code)
+
+---
+
+Made with ❤️ for the Claude Code community


### PR DESCRIPTION
## Summary by Sourcery

Enhance documentation and configuration support for the Claude Plugins Marketplace by updating the README with installation and usage instructions, adding CLAUDE.md for repository and plugin format guidance, and introducing a marketplace metadata file.

Enhancements:
- Rename repository title in README to "Duyet's Claude Plugins Marketplace"
- Revise README to include installation steps, plugin usage examples, team configuration, and license information

Deployment:
- Introduce .claude-plugin/marketplace.json to store marketplace metadata

Documentation:
- Add detailed installation and direct plugin installation instructions to README
- Include For Teams section in README for automatic marketplace setup via Claude Code settings
- Add CLAUDE.md to document repository structure, plugin format, and contribution guidelines