### PR TITLE
fix: marketplace schema validation error

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "duyets-claude-plugins",
+  "name": "duyet-claude-plugins",
   "owner": {
     "name": "Duyet",
     "url": "https://github.com/duyet"
@@ -69,7 +69,6 @@
       "description": "Analyze and optimize CLAUDE.md files based on codebase context and industry best practices. Provides actionable recommendations to improve Claude Code effectiveness, identifies anti-patterns, and suggests improvements for conciseness and progressive disclosure.",
       "version": "1.1.0",
       "category": "productivity",
-      "namespace": "duyet",
       "keywords": [
         "claude-md",
         "optimization",


### PR DESCRIPTION
- Remove unrecognized 'namespace' key from claude-md-optimizer plugin
- Rename marketplace from 'duyets-claude-plugins' to 'duyet-claude-plugins'

Fixes schema validation error: "Unrecognized key(s) in object: 'namespace'"

## Summary by Sourcery

Fix marketplace plugin configuration to comply with schema validation requirements.

Bug Fixes:
- Remove unsupported 'namespace' field from the Claude marketplace plugin configuration to satisfy schema validation.
- Update the marketplace identifier from 'duyets-claude-plugins' to 'duyet-claude-plugins' to align with the correct plugin name.