### PR TITLE
feat(team-agents): add effort level to all sub-agents

### DIFF
--- a/team-agents/.claude-plugin/plugin.json
+++ b/team-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "team-agents",
   "description": "Leader and Senior Engineer agents for coordinated parallel task execution. Leader breaks down complex tasks and delegates to multiple senior engineers working in parallel.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "duyet"
   }

--- a/team-agents/.codex-plugin/plugin.json
+++ b/team-agents/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team-agents",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Leader and Senior Engineer agents for coordinated parallel task execution. Leader breaks down complex tasks and delegates to multiple senior engineers working in parallel.",
   "author": {
     "name": "duyet"

--- a/team-agents/agents/deep-research-agent.md
+++ b/team-agents/agents/deep-research-agent.md
@@ -1,6 +1,7 @@
 ---
 name: deep-research-agent
 description: Specialist for comprehensive research with adaptive strategies, intelligent exploration, and evidence-based analysis
+effort: high
 color: green
 ---
 

--- a/team-agents/agents/junior-engineer.md
+++ b/team-agents/agents/junior-engineer.md
@@ -2,6 +2,7 @@
 name: junior-engineer
 description: Execute well-defined tasks with blazing speed and precision. Specializes in implementation from clear specifications. Works with leader and senior-engineer agents for maximum team velocity.
 model: haiku
+effort: low
 color: green
 ---
 

--- a/team-agents/agents/leader.md
+++ b/team-agents/agents/leader.md
@@ -2,6 +2,7 @@
 name: leader
 description: Coordinate complex tasks by breaking requirements into parallel workstreams, delegating to senior-engineer agents, and ensuring quality.
 model: opus
+effort: high
 color: red
 ---
 

--- a/team-agents/agents/performance-engineer.md
+++ b/team-agents/agents/performance-engineer.md
@@ -1,6 +1,7 @@
 ---
 name: performance-engineer
 description: Optimize system performance through measurement-driven analysis and bottleneck elimination
+effort: medium
 color: orange
 ---
 

--- a/team-agents/agents/python-expert.md
+++ b/team-agents/agents/python-expert.md
@@ -1,6 +1,7 @@
 ---
 name: python-expert
 description: Deliver production-ready, secure, high-performance Python code following SOLID principles and modern best practices
+effort: medium
 color: blue
 ---
 

--- a/team-agents/agents/senior-engineer.md
+++ b/team-agents/agents/senior-engineer.md
@@ -2,6 +2,7 @@
 name: senior-engineer
 description: Implement features and components from plans with high-performance, maintainable code. Works with leader agent for parallel task execution.
 model: sonnet
+effort: high
 color: purple
 ---
 


### PR DESCRIPTION
## Summary
- Add `effort` frontmatter field to all 6 team-agent sub-agents to control reasoning depth per role
- leader, senior-engineer, deep-research-agent → `high` (complex decisions, thorough analysis)
- performance-engineer, python-expert → `medium` (focused specialist work)
- junior-engineer → `low` (speed-first execution on clear specs)
- Bump plugin version 1.7.0 → 1.8.0

## Test plan
- [ ] Verify agent frontmatter parses correctly in Claude Code
- [ ] Confirm effort levels are applied when agents are spawned

## Summary by Sourcery

Add configurable effort levels to all team-agent roles to control reasoning depth and update plugin metadata accordingly.

New Features:
- Introduce an effort frontmatter field to all team-agent sub-agents to represent their reasoning depth tiers (high, medium, low).

Enhancements:
- Configure appropriate effort levels for leader, senior-engineer, deep-research-agent, performance-engineer, python-expert, and junior-engineer agents.