### PR TITLE
chore: ignore .antigravitycli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.log
 .claude/*.local.md
 .claude/*.local.json
+.antigravitycli
 node_modules/
 duyetbot/knowledge/_raw_data.txt


### PR DESCRIPTION
Exclude the Antigravity CLI's local artifacts from version control.

## Summary by Sourcery

Chores:
- Update .gitignore to exclude Antigravity CLI local artifacts from version control.