### PR TITLE
chore(antorouter): bump codex manifest version to 1.0.1

### DIFF
--- a/anyrouter/.codex-plugin/plugin.json
+++ b/anyrouter/.codex-plugin/plugin.json
@@ -14,12 +14,7 @@
     "shortDescription": "Universal OpenAI-compatible LLM router (150+ models). Migrate from Anthropic / OpenAI / OpenRouter; manage keys via MCP.",
     "developerName": "duyet",
     "category": "AI",
-    "capabilities": [
-      "Skill",
-      "Command",
-      "Agent",
-      "MCP"
-    ],
+    "capabilities": ["Skill", "Command", "Agent", "MCP"],
     "links": {
       "homepage": "https://anyrouter.dev",
       "docs": "https://anyrouter.dev/docs",

--- a/anyrouter/.codex-plugin/plugin.json
+++ b/anyrouter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anyrouter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Wire AnyRouter into Claude Code, Codex, Cursor, and other coding agents. Universal OpenAI-compatible router for 150+ models, with migration recipes from Anthropic, OpenAI, and OpenRouter, plus a remote MCP server for key and credit management.",
   "author": {
     "name": "duyet"


### PR DESCRIPTION
Bump the Codex manifest version `1.0.0 -> 1.0.1` to align with the Claude manifest, which is already at `1.0.1`. Keeps the two manifests in sync per the repo's manifest-sync rule.

## Summary by Sourcery

Chores:
- Bump anyrouter Codex plugin manifest version to 1.0.1 to keep manifests in sync.