### PR TITLE
feat(skills): Foundation Models, Apple Intelligence, macOS best practices

### DIFF
--- a/build-ios-apps/skills/apple-intelligence/SKILL.md
+++ b/build-ios-apps/skills/apple-intelligence/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: apple-intelligence
+description: Apple Intelligence participation layer. Wire an app's actions and content into Siri, Spotlight, Writing Tools, Image Playground, and summaries via App Intents, entities, and schemas. Use before adding App Intents/schemas, Spotlight indexing, Writing Tools, or Image Playground; defer custom generative features and on-device model files to the sibling skills.
+---
+
+# Apple Intelligence
+
+## Overview
+
+Apple Intelligence is the personal intelligence system behind built-in capabilities
+across Apple platforms. It runs on-device on Apple silicon and in Private Cloud
+Compute. Your app participates by teaching the system about its **actions** and
+**content** so system features — Siri, Spotlight, Shortcuts, Writing Tools, Image
+Playground, Visual Intelligence, Genmoji, and summaries — can use them.
+
+The participation contract is the **App Intents** framework: an `AppIntent` wraps one
+of your app's actions; an `AppEntity` represents the data those actions operate on.
+Apple Intelligence uses donated intents/entities, your Spotlight index, and declared
+schemas to find and act on your content — even when described vaguely.
+
+Two sibling skills handle the custom-model side and are out of scope here:
+
+- **`foundation-models`** — the Foundation Models framework for custom generative
+  features (prompting, guided generation, tool calling, Private Cloud Compute).
+- **`core-ai`** — running your own deep-learning model files (`.aimodel`) on-device.
+
+This skill covers only the built-in intelligence surfaces an app adopts.
+
+## Device eligibility and availability
+
+Apple Intelligence requires Apple silicon (iPhone 15 Pro and later, iPad with A17 Pro
+or M-series, Mac with M-series). It is opt-in via the Apple Intelligence toggle in
+Settings. Before exposing intelligence features, branch on the system model's
+`availability` rather than assuming it is on:
+
+```swift
+import FoundationModels
+
+private var model = SystemLanguageModel.default
+
+switch model.availability {
+case .available:
+    // Show your intelligence UI.
+case .unavailable(.deviceNotEligible):
+    // Show an alternative UI.
+case .unavailable(.appleIntelligenceNotEnabled):
+    // Ask the person to turn on Apple Intelligence.
+case .unavailable(.modelNotReady):
+    // Model is downloading or not ready.
+case .unavailable(let other):
+    // Unknown reason.
+}
+```
+
+## How an app participates: App Intents, entities, schemas
+
+The single biggest lever. Make the system aware of your actions and data via the App
+Intents framework:
+
+- **App intents** — a custom type encapsulating one action. Ship in your app or an app
+  extension so the action runs even when the app isn't open. Each intent performs an
+  action in `perform()`, returns a result/error, declares parameters, and provides a
+  localized title Siri and Shortcuts can display.
+- **App entities** — lightweight versions of your data objects. Define them only for
+  the subset of data people see and might reference with Siri ("this photo", "this
+  album"). Real data objects stay the source of truth.
+- **App enums** — enumerate fixed choices (e.g. repeat options) so the system can
+  resolve parameters.
+- **Donations** — when someone performs an action in your UI, donate the matching
+  intent/entity. Donations give Apple Intelligence behavioral cues to predict and
+  disambiguate. Donate only direct UI interactions, not actions Siri or Shortcuts
+  initiated.
+- **Schemas (domains)** — the predefined intent/entity shapes for common actions (mail,
+  messaging, files, etc.). Prefer building from a schema over a custom intent; schemas
+  are the contract Apple Intelligence uses to match everyday phrases.
+
+Grounded minimal `AppIntent` shape:
+
+```swift
+struct OrderAlbum: AppIntent {
+    static var title: LocalizedStringResource { "Order Album" }
+    static var description = IntentDescription("Order a vinyl record album.")
+
+    @Parameter(title: "Album", description: "The name of the album to order.")
+    var albumName: String
+
+    @Dependency
+    private var albumManager: AlbumDataManager
+
+    func perform() async throws -> some IntentResult {
+        // Perform the action...
+        return .result()
+    }
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Order \(\.$albumName)")
+    }
+}
+```
+
+> For full intent/entity/schema implementation patterns, see the sibling
+> `ios-app-intents` skill.
+
+## App Shortcuts
+
+An `AppShortcut` bundles an `AppIntent` with a title, image, preconfigured parameters,
+and spoken phrases so it appears polished in Shortcuts and other system experiences.
+The compiler generates system metadata, so shortcuts are available the moment someone
+installs your app — no registration needed. Define them in a type adopting the
+`AppShortcutProvider` protocol, alongside the intents they use. Surface them in-app
+with tip views.
+
+## Apple Intelligence + Siri AI: the extra steps
+
+Beyond a basic App Intents adoption, make content discoverable by Apple Intelligence
+specifically:
+
+- **Index entities into Spotlight** — Apple Intelligence uses Spotlight's semantic
+  search to find your content even when described vaguely. This is what makes "the
+  email from Mei about the Q3 plan" work.
+- **Choose transferable types** — conform entities/values to transferable types so the
+  system can move content across apps for cross-app Siri tasks.
+- **Adopt schemas** — the contract the system uses to identify, query, and understand
+  actions and content, and to match them to conversational phrases.
+- **Associate entities with views / user activities** — gives Apple Intelligence
+  onscreen context so someone can refer to what's visible ("this photo").
+- **Donate actions and content** — behavioral cues for prediction and disambiguation.
+
+## Spotlight / semantic indexing
+
+Indexing your app's content makes it findable in search and lets Siri and other system
+features locate app-specific data. If you define app entities for your data, index
+those entities with the rest of your content. When a search finds your content, the
+system uses the associated entity to open your app and navigate to it. Apple
+Intelligence retrieves entities it finds in your Spotlight index to interact with your
+content.
+
+## Writing Tools and Genmoji
+
+Writing Tools (proofreading, rewrite, summaries) integrate into standard system text
+views automatically:
+
+- Adopt `NSAttributedString` / attributed strings as the backing store for text content.
+- Use standard text views whenever possible and customize via their configuration
+  options.
+- Use the Writing Tools API directly only if you have a custom text-editing engine or
+  can't use system views.
+- Genmoji is built into system text views. In custom views, add Genmoji text
+  attachments and read/write them correctly when persisting to a custom file format.
+
+## Image Playground
+
+The ImagePlayground framework gives a system interface to generate images from a text
+description, an optional source image, and a style. Present a system sheet (SwiftUI) or
+view controller (UIKit/AppKit); the system manages all interaction and delivers the
+resulting image. Key API surface:
+
+- `ImagePlaygroundViewController` — the standard system interface (UIKit/AppKit).
+- `ImagePlaygroundConcept` — text elements specifying content to include.
+- `ImagePlaygroundStyle` / `ImagePlaygroundOptions` — style and generation options.
+- `ImageCreator` — generate images programmatically without the UI.
+- SwiftUI sheet modifier:
+
+```swift
+imagePlaygroundSheet(
+    isPresented: Binding<Bool>,
+    concept: String,          // or concepts: [ImagePlaygroundConcept]
+    sourceImage: Image?,      // or sourceImageURL: URL
+    onCompletion: (URL) -> Void,
+    onCancellation: (() -> Void)?
+)
+```
+
+## Visual Intelligence
+
+For object/scene scanning via Camera Control, adopt Visual Intelligence. The framework
+detects content and exchanges information with your app using App Intents — so your App
+Intents participation is also what makes you a destination for Visual Intelligence
+results.
+
+## Checklist
+
+- [ ] Check `SystemLanguageModel.default.availability` before showing intelligence UI;
+      handle `.deviceNotEligible` and `.appleIntelligenceNotEnabled`.
+- [ ] Identified the user-visible actions and data; modeled them as `AppIntent` and
+      `AppEntity`.
+- [ ] Built common actions from built-in schema domains (not bespoke intents) where one
+      exists.
+- [ ] Each intent has `perform()`, a result/error, declared `@Parameter`s, and a
+      localized `title`.
+- [ ] Entities are lightweight and cover only what people see/reference.
+- [ ] Donating intents/entities on direct UI interactions (not Siri/Shortcuts ones).
+- [ ] App entities indexed into Spotlight (enables semantic search by Apple
+      Intelligence).
+- [ ] Entities associated with views/user activities for onscreen context.
+- [ ] Conformed entities to transferable types for cross-app Siri tasks.
+- [ ] App Shortcuts defined via `AppShortcutProvider` for headline actions.
+- [ ] Text content backed by attributed strings; Writing Tools and Genmoji handled in
+      custom text views.
+- [ ] Image Playground adopted via `imagePlaygroundSheet` / `ImagePlaygroundViewController`
+      (or `ImageCreator` for programmatic generation).
+- [ ] Custom generative features delegated to `foundation-models`; on-device model files
+      to `core-ai`.
+- [ ] Tested intents end-to-end (Siri, Spotlight, Shortcuts) on a real eligible device.
+
+## Resources
+
+- Apple Intelligence overview — <https://developer.apple.com/documentation/technologyoverviews/apple-intelligence>
+- Built-in intelligence (on-device vision/speech/NLP) — <https://developer.apple.com/documentation/technologyoverviews/built-in-intelligence>
+- Generative models overview — <https://developer.apple.com/documentation/technologyoverviews/generative-models>
+- Apple Intelligence and Siri AI — <https://developer.apple.com/documentation/appintents/apple-intelligence-and-siri-ai>
+- Spotlight integration — <https://developer.apple.com/documentation/appintents/spotlight>
+- Donations and discovery — <https://developer.apple.com/documentation/appintents/donations-and-discovery>
+- Getting started with App Intents — <https://developer.apple.com/documentation/appintents/getting-started-with-the-app-intents-framework>
+- App entities — <https://developer.apple.com/documentation/appintents/app-entities>
+- App Shortcuts — <https://developer.apple.com/documentation/appintents/app-shortcuts>
+- AppIntent protocol — <https://developer.apple.com/documentation/appintents/appintent>
+- Image Playground — <https://developer.apple.com/documentation/imageplayground>
+- Foundation Models quick start (eligibility code) — <https://developer.apple.com/documentation/foundationmodels/generating-content-and-performing-tasks-with-foundation-models>
+- Sibling skills: `foundation-models`, `core-ai`, `ios-app-intents`

--- a/build-ios-apps/skills/foundation-models/SKILL.md
+++ b/build-ios-apps/skills/foundation-models/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: foundation-models
+description: Build on-device generative AI with Apple's Foundation Models framework. Use the system language model (Apple Intelligence) for text generation, structured output via @Generable and GenerationSchema, tool calling, and multimodal prompts through a LanguageModelSession.
+---
+
+# Foundation Models
+
+## Overview
+
+Foundation Models is Apple's generative-AI framework for intelligent app features. You
+drive a language model through a `LanguageModelSession` — generating text, structuring
+output into Swift types with guided generation (`@Generable`, `GenerationSchema`), and
+letting the model call your own `Tool`s during generation. The default backend is the
+**system language model** (`SystemLanguageModel`), which runs on Apple Intelligence
+(iPhone, iPad, and Mac with Apple silicon). The same session API also targets
+**Private Cloud Compute** (`PrivateCloudComputeLanguageModel`, server-side) or a
+**custom language model provider**, so session code is portable across backends.
+
+Before any feature, gate on availability — the model can be unavailable for several
+reasons:
+
+```swift
+private var model = SystemLanguageModel.default
+
+switch model.availability {
+case .available:
+    // Show your intelligence UI.
+case .unavailable(.deviceNotEligible):
+    // Device can't run the model; offer an alternative.
+case .unavailable(.appleIntelligenceNotEnabled):
+    // Ask the person to turn on Apple Intelligence.
+case .unavailable(.modelNotReady):
+    // Still downloading or otherwise not ready.
+case .unavailable(let other):
+    // Other system reason.
+}
+```
+
+## Essentials
+
+Create a session and respond to a prompt. `respond(to:)` is async and throws.
+
+```swift
+let session = LanguageModelSession()
+let response = try await session.respond(to: "Write a profile for a dog breed.")
+print(response.content)
+```
+
+Instructions give the session persistent behavior; `GenerationOptions` (e.g.
+`temperature`) tunes sampling; `ContextOptions` manages the context window:
+
+```swift
+let session = LanguageModelSession(instructions: """
+    Suggest five related topics. Keep them concise (three to seven words).
+    """)
+
+let response = try await session.respond(to: "Making homemade bread")
+
+// More creative sampling.
+let session2 = LanguageModelSession()
+let r = try await session2.respond(
+    to: "Write me a story about coffee.",
+    options: GenerationOptions(temperature: 1.0)
+)
+```
+
+Use `LanguageModelSession(model:)` to target a backend, and the session's streaming API
+to receive output incrementally for long generations.
+
+## Structured Output (Guided Generation)
+
+Generate typed data instead of free text. For primitives, pass the type directly:
+
+```swift
+let r = try await session.respond(to: "How many tablespoons are in a cup?",
+                                  generating: Float.self)
+```
+
+For custom types, conform to `Generable` and guide fields with `@Guide` (supports
+constraints such as `.range(...)`):
+
+```swift
+@Generable(description: "Basic profile information about a cat")
+struct CatProfile {
+    var name: String
+
+    @Guide(description: "The age of the cat", .range(0...20))
+    var age: Int
+
+    @Guide(description: "A one sentence profile about the cat's personality")
+    var profile: String
+}
+
+let r = try await session.respond(to: "Generate a cute rescue cat",
+                                  generating: CatProfile.self)
+```
+
+For schemas built at runtime, assemble `DynamicGenerationSchema` nodes into a
+`GenerationSchema`, then pass `schema:`:
+
+```swift
+let menuSchema = DynamicGenerationSchema(
+    name: "Menu",
+    properties: [
+        DynamicGenerationSchema.Property(
+            name: "dailySoup",
+            schema: DynamicGenerationSchema(
+                name: "dailySoup",
+                anyOf: ["Tomato", "Chicken Noodle", "Clam Chowder"]
+            )
+        )
+        // Add additional properties.
+    ]
+)
+
+let schema = try GenerationSchema(root: menuSchema, dependencies: [])
+let r = try await session.respond(to: "What is today's menu?", schema: schema)
+```
+
+## Tool Calling
+
+Let the model invoke your code during generation. Conform to `Tool`; describe arguments
+with `@Generable` and return simple, model-friendly content from `call(arguments:)`:
+
+```swift
+struct BreadDatabaseTool: Tool {
+    let name = "searchBreadDatabase"
+    let description = "Searches a local database for bread recipes."
+
+    @Generable struct Arguments {
+        @Guide(description: "The type of bread to search for")
+        var searchTerm: String
+
+        @Guide(description: "The number of recipes to get", .range(1...6))
+        var limit: Int
+    }
+
+    func call(arguments: Arguments) async throws -> [String] {
+        // Retrieve recipes from your database, then return formatted strings.
+        return []
+    }
+}
+
+let session = LanguageModelSession(tools: [BreadDatabaseTool()])
+let r = try await session.respond(to: "Find three sourdough bread recipes")
+```
+
+## Choosing a Backend
+
+- `SystemLanguageModel.default` — on-device, Apple Intelligence. Private and
+  offline-capable; the default for most features.
+- `PrivateCloudComputeLanguageModel` — same session API, runs server-side on Apple's
+  cloud. Requires the `com.apple.developer.private-cloud-compute` entitlement. Use when
+  you need a larger cloud model; reuse your existing session code.
+- Custom language model provider — bring your own model behind the same session API.
+
+Attach images with `Attachment` / `ImageAttachmentContent` for multimodal prompting and
+image analysis.
+
+## Checklist
+
+- [ ] Check `SystemLanguageModel.default.availability`; provide a fallback for each case.
+- [ ] Use `LanguageModelSession`, with `instructions:` for persistent guidance.
+- [ ] Prefer guided generation (`@Generable` / `@Guide` or `GenerationSchema`) over
+      parsing free text.
+- [ ] Constrain numeric fields with `@Guide` ranges; validate generated values.
+- [ ] Expose app capabilities as `Tool`s that return simple, model-friendly content.
+- [ ] Pick the backend deliberately: system vs Private Cloud Compute vs custom provider.
+- [ ] Stream long responses and manage the context window with `ContextOptions`.
+- [ ] Evaluate prompts and responses, and apply safety guidance for generative output.
+
+## Related skills
+
+- `apple-intelligence` — the participation layer (Siri, Spotlight, Writing Tools, Image
+  Playground) that surrounds on-device generation.
+- `core-ai` — running your own model files (`.aimodel`) at the tensor level, for
+  features that are not language-model shaped.
+
+## Resources
+
+- Apple — Foundation Models: <https://developer.apple.com/documentation/foundationmodels>
+- Generating content and performing tasks with Foundation Models
+- Generating Swift data structures with guided generation
+- Expanding generation with tool calling
+- Prefer Apple docs for up-to-date API details; web-search the current Foundation Models
+  documentation alongside this skill.

--- a/build-macos-apps/skills/macos-app-best-practices/SKILL.md
+++ b/build-macos-apps/skills/macos-app-best-practices/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: macos-app-best-practices
+description: Best practices for building macOS apps with SwiftUI, AppKit, and Mac Catalyst. Use when architecting a Mac app, choosing scene and window types, wiring menus and commands, or deciding between native SwiftUI, AppKit, and Mac Catalyst.
+---
+
+# macOS App Best Practices
+
+## Overview
+
+macOS apps are organized around scenes the system manages: windows, document groups,
+settings, and menu-bar extras. Pick the right scene types for SwiftUI, gate Mac-only
+behavior behind `#if os(macOS)`, and reserve Mac Catalyst for bringing an existing iPad
+app to the Mac rather than starting new Mac apps on it. The guidance below is grounded
+in Apple's SwiftUI, AppKit, and Mac Catalyst docs.
+
+## App Architecture: Scenes
+
+A `Scene` is a root of a view hierarchy with a system-managed life cycle; an `App`
+presents its scenes. The system shows scenes differently per type and platform, and may
+display several instances of one `WindowGroup` at once (for example, multiple windows).
+
+- Default to `WindowGroup` for the main window.
+- Use `DocumentGroup` for document-based apps (it adds Save/Duplicate to the menu bar
+  automatically).
+- Use `Settings` (macOS only) for the app-menu Settings window.
+- Use `MenuBarExtra` for utility apps or a persistent status item.
+
+```swift
+@main
+struct Mail: App {
+    var body: some Scene {
+        WindowGroup {
+            MailViewer()
+        }
+        // A typed window group keyed by a model id.
+        WindowGroup(for: Message.ID.self) { $messageID in
+            MessageDetail(messageID: messageID)
+        }
+    }
+}
+```
+
+## Opening and Identifying Windows
+
+Give a `WindowGroup` an `id` and open instances via the `openWindow` environment action,
+matching the group id. This is how a Mac app supports multiple windows from one
+declaration.
+
+```swift
+WindowGroup(id: "mail-viewer") {
+    MailViewer()
+}
+
+struct NewViewerButton: View {
+    @Environment(\.openWindow) private var openWindow
+    var body: some View {
+        Button("Open new mail viewer") { openWindow(id: "mail-viewer") }
+    }
+}
+```
+
+## Settings Window (macOS only)
+
+`Settings` presents the App-menu > Settings window. Gate it with `#if os(macOS)`.
+`@AppStorage` persists the bound values.
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup { ContentView() }
+        #if os(macOS)
+        Settings { GeneralSettingsView() }
+        #endif
+    }
+}
+
+struct GeneralSettingsView: View {
+    @AppStorage("showPreview") private var showPreview = true
+    @AppStorage("fontSize") private var fontSize = 12.0
+    var body: some View {
+        Form {
+            Toggle("Show Previews", isOn: $showPreview)
+            Slider(value: $fontSize, in: 9...96) { Text("Font Size") }
+        }
+    }
+}
+```
+
+## Menu Bar Extra
+
+`MenuBarExtra` renders a persistent control in the system menu bar. A utility app can
+use it as the sole scene. `.menuBarExtraStyle(.window)` shows a panel with arbitrary
+SwiftUI content.
+
+```swift
+@main
+struct UtilityApp: App {
+    var body: some Scene {
+        MenuBarExtra("Utility App", systemImage: "hammer") {
+            AppMenu()
+        }
+    }
+}
+
+// Toggle a status item on/off.
+MenuBarExtra("App Menu Bar Extra", systemImage: "star", isInserted: $show) {
+    StatusMenu()
+}
+
+// Window-styled panel.
+MenuBarExtra("Utility App", systemImage: "hammer") {
+    ScrollView { /* LazyVGrid content */ }
+}
+.menuBarExtraStyle(.window)
+```
+
+## Menus and Commands
+
+The menu bar is populated from your scenes plus `.commands { }` modifiers. Scene
+defaults differ: `WindowGroup` adds quit/hide, Copy/Paste, and window management; on
+macOS the `Settings` scene adds the App-menu > Settings item; `DocumentGroup` adds
+Save/Duplicate. The order of system menus is fixed; custom menus insert after the View
+menu.
+
+- Add system command groups contextually: `SidebarCommands()` only if your scene has a
+  sidebar; text-editing scenes get a Format menu via `TextFormattingCommands`.
+- Build custom menus with `CommandMenu("Actions")` using standard `Button`/`Toggle`
+  views, and bind `.keyboardShortcut(...)`.
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        DocumentGroup(newDocument: MyAppDocument()) { file in
+            ContentView(document: file.$document)
+        }
+        .commands { SidebarCommands() }
+
+        WindowGroup {
+            ContentView()
+        }
+        .commands {
+            CommandMenu("Actions") {
+                Button("Run") { /* ... */ }.keyboardShortcut("R")
+                Button("Stop") { /* ... */ }.keyboardShortcut(".")
+            }
+        }
+    }
+}
+```
+
+## SwiftUI vs AppKit
+
+- SwiftUI is the default for new Mac UI; AppKit remains the layer for advanced or legacy
+  controls and when a SwiftUI equivalent is missing.
+- SwiftUI symbols and scenes provide the cross-platform contract; gate Mac-specific
+  scenes (`Settings`, `MenuBarExtra`) and platform-only modifiers with `#if os(macOS)`.
+- For AppKit bridging details, use `appkit-interop`; this skill stays at the
+  architecture/decision level.
+
+## Mac Catalyst (iPad app to Mac)
+
+Mac Catalyst produces a Mac version of an iPad app from the same project and source. In
+Xcode: iOS target > General > Supported Destinations > add **Mac > Mac Catalyst**. Xcode
+adds the Mac entitlement to the Mac build only and adds a "My Mac" destination.
+
+- Mac Catalyst apps can use only APIs available in Mac Catalyst; AppKit APIs are not
+  accessible from Catalyst.
+- Exclude incompatible frameworks by setting the platform filter to iOS only in
+  Frameworks, Libraries, and Embedded Content.
+- Gate code with `#if !targetEnvironment(macCatalyst)` (unavailable API) and
+  `#if targetEnvironment(macCatalyst)` (macOS-only).
+
+Choose the UI idiom in Xcode after enabling Mac Catalyst:
+
+- **Scale Interface to Match iPad** — iPad idiom. Fastest; UI scaled to the Mac with
+  iPad-like metrics. The default.
+- **Optimize Interface for Mac** — Mac idiom. Controls look and behave like AppKit;
+  points equal AppKit points. May require re-laying out hard-coded sizes and constraints.
+  Detect via `traitCollection.userInterfaceIdiom == .mac`.
+
+```swift
+// Tailor behavior for the Mac idiom.
+if traitCollection.userInterfaceIdiom == .mac {
+    showFavoritesAtTop.preferredStyle = .checkbox
+    showFavoritesAtTop.title = "Always show favorite recipes at the top"
+}
+
+// Keep a control's iPad appearance in the Mac idiom.
+slider.preferredBehavioralStyle = .pad
+```
+
+macOS features you get for free with Catalyst: default menu bar, pointer/mouse/keyboard
+input, window resizing and full screen, Mac-style scroll bars, copy/paste, drag and
+drop, Touch Bar. Extend with custom menu bar items (`UIMenuBuilder`), a Settings window
+(auto-provided with a Settings bundle), pointer hover (`UIHoverGestureRecognizer`), and a
+Liquid Glass sidebar background
+(`splitViewController.primaryBackgroundStyle = .sidebar`).
+
+```swift
+// Pointer hover (Catalyst + macOS).
+let hover = UIHoverGestureRecognizer(target: self, action: #selector(hovering(_:)))
+button.addGestureRecognizer(hover)
+
+@objc func hovering(_ r: UIHoverGestureRecognizer) {
+    switch r.state {
+    case .began, .changed: button.titleLabel?.textColor = .red
+    case .ended:           button.titleLabel?.textColor = .link
+    default: break
+    }
+}
+
+// Use .alert (not .actionSheet) under Mac Catalyst.
+#if targetEnvironment(macCatalyst)
+let style = UIAlertController.Style.alert
+#else
+let style = UIAlertController.Style.actionSheet
+#endif
+```
+
+## Checklist
+
+- [ ] Main UI in a `WindowGroup`; document apps in `DocumentGroup`.
+- [ ] App-menu settings via `Settings { }` gated with `#if os(macOS)`.
+- [ ] Utility/status UI via `MenuBarExtra` (`.menuBarExtraStyle(.window)` for panels).
+- [ ] Multi-window: id the group and open with `@Environment(\.openWindow)`.
+- [ ] Menus via `.commands { }`; add `SidebarCommands` / `TextFormattingCommands` only
+      when relevant; custom items in `CommandMenu` with `keyboardShortcut`.
+- [ ] Mac-only scenes and modifiers wrapped in `#if os(macOS)`.
+- [ ] Mac Catalyst: no AppKit calls; gate with `#if targetEnvironment(macCatalyst)`;
+      pick Scale-to-iPad vs Optimize-for-Mac deliberately; detect via
+      `userInterfaceIdiom == .mac`.
+- [ ] Build verified for "My Mac" (native) and "My Mac (Catalyst)" destinations.
+
+## When To Use Other Skills
+
+- `swiftui-patterns` — concrete scene/window/toolbar/settings/split-view implementations.
+- `window-management` — window chrome, placement, restoration, borderless windows.
+- `appkit-interop` — reaching AppKit (NSWindow, panels, responder chain) from SwiftUI.
+- `signing-entitlements` / `packaging-notarization` — ship the app once it builds.
+
+## Resources
+
+- <https://developer.apple.com/documentation/technologyoverviews/app-design-and-ui>
+- <https://developer.apple.com/documentation/swiftui/app-structure>
+- <https://developer.apple.com/documentation/swiftui/scene>
+- <https://developer.apple.com/documentation/swiftui/windowgroup>
+- <https://developer.apple.com/documentation/swiftui/settings>
+- <https://developer.apple.com/documentation/swiftui/menubarextra>
+- <https://developer.apple.com/documentation/swiftui/building-and-customizing-the-menu-bar-with-swiftui>
+- <https://developer.apple.com/documentation/uikit/mac-catalyst>
+- <https://developer.apple.com/documentation/uikit/creating-a-mac-version-of-your-ipad-app>
+- <https://developer.apple.com/documentation/uikit/choosing-a-user-interface-idiom-for-your-mac-app>
+- <https://developer.apple.com/documentation/uikit/optimizing-your-ipad-app-for-mac>


### PR DESCRIPTION
Three new skills extracted from Apple's DocC docs (web tools were rate-limited, so content came via the DocC JSON API).

- `foundation-models` (build-ios-apps): on-device generative AI — `LanguageModelSession`, `SystemLanguageModel` availability, `@Generable`/`GenerationSchema` guided generation, `Tool` calling, system / Private Cloud Compute / custom-provider backends.
- `apple-intelligence` (build-ios-apps): the participation layer — App Intents/entities/schemas, Spotlight semantic indexing, Writing Tools, Image Playground. Cross-references `foundation-models`, `core-ai`, `ios-app-intents`.
- `macos-app-best-practices` (build-macos-apps): scene/window/menu architecture, `Settings`/`MenuBarExtra`, commands, SwiftUI vs AppKit vs Mac Catalyst (Scale-to-iPad vs Optimize-for-Mac).

All lint-clean (prettier, no lines >400); `validate-plugins.sh` passes (skills auto-discovered, no manifest/marketplace changes).

Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>